### PR TITLE
remove unnecessary trait bound

### DIFF
--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -2,9 +2,7 @@ use std::io;
 use tracing::{subscriber::set_global_default, Subscriber};
 use tracing_bunyan_formatter::{BunyanFormattingLayer, JsonStorageLayer};
 use tracing_log::LogTracer;
-use tracing_subscriber::{
-    fmt::MakeWriter, prelude::__tracing_subscriber_SubscriberExt, EnvFilter, Registry,
-};
+use tracing_subscriber::{prelude::__tracing_subscriber_SubscriberExt, EnvFilter, Registry};
 
 /// Compose multiple layers into a tracing subscriber
 pub fn get_subscriber<'a, F, W>(
@@ -13,7 +11,7 @@ pub fn get_subscriber<'a, F, W>(
     sink: F,
 ) -> impl Subscriber + Send + Sync
 where
-    F: MakeWriter<'a> + Fn() -> W + Send + Sync + 'static,
+    F: Fn() -> W + Send + Sync + 'static,
     W: io::Write,
 {
     let env_filter =


### PR DESCRIPTION
This is necessary to continue to compile in future Rust versions as this previously only compiled due to an underspecified part of the type system. It will stop compiling once https://github.com/rust-lang/rust/pull/119820 lands.

The where bound `F: MakeWriter<'a>` is weaker than the required bound of `BunyanFormattingLayer` which requires `for<'a> F: MakeWriter<'a>`, i.e. `F` implements `MakeWriter<'a>` for all lifetimes `'a`, not just the lifetime `'a` used when calling the function. This bound does hold because of an implementation of `MakeWriter` for all types which implement `Fn() -> W`. However, we generally prefer where-bounds over impls when proving trait bounds, causing us to get a higher-ranked region error.

This error was previously detected more eagerly, causing the compiler to discard this where-bound, proving the requirement by using the impl instead. This now stops being the case, causing your code to error.

Please ask for clarification if you would like further information. I apologize for the inconvenience.